### PR TITLE
fix: proc handling on Linux

### DIFF
--- a/audio_meter.go
+++ b/audio_meter.go
@@ -77,7 +77,7 @@ When lambda returns false, the listening stops
 */
 func Monitor(deviceInfo malgo.DeviceInfo, dbfsLevels chan DbfsLevel, stop chan bool) {
 	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(message string) {
-		fmt.Printf(message)
+		print(message)
 	})
 	chk(err)
 	defer func() {
@@ -117,7 +117,7 @@ func Monitor(deviceInfo malgo.DeviceInfo, dbfsLevels chan DbfsLevel, stop chan b
 	for {
 		select {
 		case <-stop:
-			fmt.Println("Stopping monitoring...")
+			print("Stopping monitoring...")
 			device.Uninit()
 			return
 		default:
@@ -133,18 +133,19 @@ func sanitize(input string) string {
 }
 
 func max(a, b int) int {
-    if a > b {
-        return a
-    }
-    return b
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func isSimilar(a, b string) bool {
 	distance := levenshtein.DistanceForStrings([]rune(a), []rune(b), levenshtein.DefaultOptions)
 	maxLength := max(len(a), len(b))
-	threshold := 0.2 // This threshold can be adjusted if a match cannot be found
+	threshold := 0.6 // This threshold can be adjusted if a match cannot be found
+	similarity := float64(distance) / float64(maxLength)
 
-	return float64(distance)/float64(maxLength) < threshold
+	return similarity < threshold
 }
 
 func FindAudioDevice(name string) (malgo.DeviceInfo, error) {

--- a/varanny.go
+++ b/varanny.go
@@ -216,6 +216,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown modem process gracefully failed, killing")
 				modemCmd.Process.Kill()
 			}
+			processState, err := modemCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of modem process failed")
+			}
 			modemCmd.Process.Release()
 		}
 
@@ -232,6 +236,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown cat control process gracefully failed, killing")
 				catCtrlCmd.Process.Kill()
 			}
+			processState, err := catCtrlCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of modem process failed")
+			}
 			catCtrlCmd.Process.Release()
 		}
 
@@ -247,7 +255,7 @@ func handleConnection(conn net.Conn, p *program) {
 
 		close(dbfsLevels)
 		close(cmdChannel)
-		//		close(stop)
+		close(stop)
 	}()
 
 	// Start a separate goroutine to read from a TCP socket


### PR DESCRIPTION
   - Added .Wait() statements to await process termination and avoid defunct process trees - found this fixed varanny's ability to reliably start again after a connection to a Winlink gateway finishes
   - Also:
      - fix: relaxed fuzzy match threshold in audio_meter.go - tested on multiple systems, feel better with this value