### PR TITLE
fix: Linux process cleanup

### DIFF
--- a/varanny.go
+++ b/varanny.go
@@ -216,6 +216,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown modem process gracefully failed, killing")
 				modemCmd.Process.Kill()
 			}
+			processState, err := modemCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of modem process failed")
+			}
 			modemCmd.Process.Release()
 		}
 
@@ -232,6 +236,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown cat control process gracefully failed, killing")
 				catCtrlCmd.Process.Kill()
 			}
+			processState, err := catCtrlCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of cat control process failed")
+			}
 			catCtrlCmd.Process.Release()
 		}
 
@@ -247,7 +255,7 @@ func handleConnection(conn net.Conn, p *program) {
 
 		close(dbfsLevels)
 		close(cmdChannel)
-		//		close(stop)
+		close(stop)
 	}()
 
 	// Start a separate goroutine to read from a TCP socket


### PR DESCRIPTION
* varanny was creating defunct processes on Linux as it was not properly waiting and reaping the processes it spawned, these changes fix that