### PR TITLE
feat: added control over matching audio interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,18 +136,20 @@ To configure `varanny`, edit the `varanny.json` file as per your needs.
 Configuration must be a valid `.json` file. You can define as many "modems" as you'd like. This can be handy if you use the same computer to connect to multiple radios that require different configurations. If you need to run VARA with different parameters, simply clone your VARA `.ini` configuration file and specify it as the `Config` attribute in `varanny.json`.
 
 * `Port` port that `varanny` agent binds to. Default is 8273.
-* 'Delay` delay before `varanny` binds to a network interface. This is useful to let some time for other software to establish a HotSpot configuration when booting up. Default is set to 10s.
+* `Delay` delay before `varanny` binds to a network interface. This is useful to let some time for other software to establish a HotSpot configuration when booting up. Default is set to 10s.
+* `AudioInputNameThreshold` an optional value between 0 (completely different) and 1 (exact match). Specifies how different the name of the audio input interface can be between what's in `VARA.ini` and the system to be considered a match. Default is 0.7.
 * `Modems` arrray containing modem definitions.
-* `Name` name the modem will be advertised under. **Must be unique**.
-* `Type` type of VARA modem, `fm` or `hf`.
-* `Cmd` fully qualified path to the executable to start this VARA modem. Note for Windows paths, the backslash separators must be escaped using `\\`
-* `Args` optional arguments to pass to the executable.
-* `Config` optional path to a VARA configuration file. If present, upon starting a session, a backup of the existing `VARA.ini` or `VARAFM.ini` file is created and then the specified configuration file is applied. Once the session concludes, the original `.ini` file is restored. This feature ensures the preservation of original settings while enabling different configurations for specific setups such as a sound card name.
-* `CatCtrl` optional CAT control definition.
-* `Port` port used by the CAT control agent.
-* `Dialect` protocol used by the CAT control agent. Currently only `hamlib` is supported.
-* `Cmd` fully qualified path to the executable to start the CAT control agent. Note for Windows paths, the backslash separators must be escaped using `\\`
-* `Args` optional arguments to pass to the executable.
+   * `Name` name the modem will be advertised under. **Must be unique**.
+   * `Type` type of VARA modem, `fm` or `hf`.
+   * `Cmd` fully qualified path to the executable to start this VARA modem. Note for Windows paths, the backslash separators must be escaped using `\\`
+   * `Args` optional arguments to pass to the executable.
+   * `AudioInputName` an optional value to specify the system audio input interface name. If present, `varanny` will use this over what is specified in `VARA.ini`
+   * `Config` optional path to a VARA configuration file. If present, upon starting a session, a backup of the existing `VARA.ini` or `VARAFM.ini` file is created and then the specified configuration file is applied. Once the session concludes, the original `.ini` file is restored. This feature ensures the preservation of original settings while enabling different configurations for specific setups such as a sound card name.
+   * `CatCtrl` optional CAT control definition.
+      * `Port` port used by the CAT control agent.
+      * `Dialect` protocol used by the CAT control agent. Currently only `hamlib` is supported.
+      * `Cmd` fully qualified path to the executable to start the CAT control agent. Note for Windows paths, the backslash separators must be escaped using `\\`
+      * `Args` optional arguments to pass to the executable.
 
 [Sample Configuration](https://github.com/islandmagic/varanny/blob/master/varanny.json)
 

--- a/audio_meter.go
+++ b/audio_meter.go
@@ -77,7 +77,7 @@ When lambda returns false, the listening stops
 */
 func Monitor(deviceInfo malgo.DeviceInfo, dbfsLevels chan DbfsLevel, stop chan bool) {
 	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(message string) {
-		fmt.Printf(message)
+		print(message)
 	})
 	chk(err)
 	defer func() {
@@ -117,7 +117,7 @@ func Monitor(deviceInfo malgo.DeviceInfo, dbfsLevels chan DbfsLevel, stop chan b
 	for {
 		select {
 		case <-stop:
-			fmt.Println("Stopping monitoring...")
+			print("Stopping monitoring...")
 			device.Uninit()
 			return
 		default:
@@ -133,18 +133,19 @@ func sanitize(input string) string {
 }
 
 func max(a, b int) int {
-    if a > b {
-        return a
-    }
-    return b
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func isSimilar(a, b string) bool {
 	distance := levenshtein.DistanceForStrings([]rune(a), []rune(b), levenshtein.DefaultOptions)
 	maxLength := max(len(a), len(b))
-	threshold := 0.2 // This threshold can be adjusted if a match cannot be found
+	threshold := 0.6 // This threshold can be adjusted if a match cannot be found
+	similarity := float64(distance) / float64(maxLength)
 
-	return float64(distance)/float64(maxLength) < threshold
+	return similarity < threshold
 }
 
 func FindAudioDevice(name string) (malgo.DeviceInfo, error) {

--- a/varanny.go
+++ b/varanny.go
@@ -216,6 +216,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown modem process gracefully failed, killing")
 				modemCmd.Process.Kill()
 			}
+			processState, err := modemCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of modem process failed")
+			}
 			modemCmd.Process.Release()
 		}
 
@@ -232,6 +236,10 @@ func handleConnection(conn net.Conn, p *program) {
 				log.Println("Shutdown cat control process gracefully failed, killing")
 				catCtrlCmd.Process.Kill()
 			}
+			processState, err := catCtrlCmd.Process.Wait()
+			if err != nil || processState.Success() {
+				log.Println("Warning: awaiting termination of cat control process failed")
+			}
 			catCtrlCmd.Process.Release()
 		}
 
@@ -247,7 +255,7 @@ func handleConnection(conn net.Conn, p *program) {
 
 		close(dbfsLevels)
 		close(cmdChannel)
-		//		close(stop)
+		close(stop)
 	}()
 
 	// Start a separate goroutine to read from a TCP socket


### PR DESCRIPTION
When testing on multiple Linux systems, I found I wanted to make the fuzzy match threshold configurable at runtime. While I was making these changes, I also thought it could be a nice idea to add a way to just go ahead and assert what the audio input device name is for a given modem, and ignore what VARA has to say. I like that varanny's default behavior is to auto-detect it from the .ini file, but having an override it is a nice fallback.

While adding these updates, I also updated the ergonomics of the fuzzy match threshold and fixed some lint.

    * Added "AudioInputNameThreshold" to config
       * Similarity normalized so "0" means no match, and "1" means
         strings are identical
    * Added "AudioInputName" to modem section to assert audio device
      input name if for whatever reason fuzzy matching should fail
    * Changed Delay configuration such that it can be set to 0 in
      the config (start with no delay)